### PR TITLE
added fallback default for undefined _condition function on add_transition

### DIFF
--- a/scripts/SnowState/SnowState.gml
+++ b/scripts/SnowState/SnowState.gml
@@ -887,6 +887,8 @@ function SnowState(_initState, _execEnter = true) constructor {
 			__snowstate_error("Destination state name can not be the same as SNOWSTATE_WILDCARD_TRANSITION_NAME.");
 			return undefined;
 		}
+		
+		_condition ??= function(){ return true; };
 			
 		if (!__is_really_a_method(_condition)) {
 			__snowstate_error("Invalid value for \"condition\" in add_transition(). Should be a function.");


### PR DESCRIPTION
This is a small change to allow setting `undefined` for the `_condition` function when changing it is not necessary while overriding the `leave` or `enter` methods.

It's mostly a convenience fallback for not having to write out `function(){ return true; }` instead.

Feel free to unravel the null-coalesce if preferred. :)

Example code: 
```
.add_transition("t_reviving_idle", ENTITY_STATE.REVIVING, ENTITY_STATE.IDLE, 
    undefined,   // condition function, will fall back to function(){ return true; }
    function(){   // override leave function
        hitpoints_bar.visible = true;
    }
);
```